### PR TITLE
feat(test): add PUnit Pike unit tests for pure-function modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Verify Pike
         run: pike --version
 
-      - name: Run tests
+      - name: Run shell tests
         run: sh tests/test_install.sh
+
+      - name: Run Pike unit tests
+        run: sh tests/pike_tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ pmp (Pike Module Package Manager) installs, versions, and resolves dependencies 
 ## Setup commands
 
 - Run all tests: `sh tests/test_install.sh`
+- Run Pike unit tests: `sh tests/pike_tests.sh`
 - Verify syntax: `pike bin/pmp.pike --help`
 - Check version: `pike bin/pmp.pike version` (or `sh bin/pmp version`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,9 @@ bin/Pmp.pmod/          Stateless module library (10 files)
   Validate.pmod        validate_manifests, strip_comments_and_strings, init_std_libs
   Semver.pmod          parse_semver, compare_semver, sort_tags_semver, classify_bump
   module.pmod          Re-exports all sub-modules (14 total) via inherit
-tests/test_install.sh  Test suite (pure sh, 60 tests)
+tests/pike_tests.sh     Entry point for Pike unit tests (installs PUnit, runs tests/pike/run.pike)
+tests/pike/             PUnit test files (SemverTests, SourceTests, LockfilePureTests, HelpersTests)
+tests/test_install.sh   Shell integration test suite (114 tests)
 
 ## System Diagram
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added PUnit as a dev dependency (`pike.json`) with Pike-level unit tests (81 tests) for `Semver`, `Source`, `Lockfile`, and `Helpers` pure-function modules
+- Added `tests/pike_tests.sh` entry point — installs PUnit and runs tests via `sh tests/pike_tests.sh`
+- Added `tests/pike/` directory with `run.pike` harness and 4 test files: `SemverTests.pike`, `SourceTests.pike`, `LockfilePureTests.pike`, `HelpersTests.pike`
 ### Added
 - Adopted ai-project-template v0.2.0 — added `.editorconfig`, `.gitattributes`, `.architecture.yml`, issue/PR templates, CODEOWNERS, SECURITY.md, dependabot.yml, commit-lint/changelog-check/blob-size-policy workflows, `.omp/` agent definitions, `docs/ci.md`, and ADR 0001
 - Restructured test suite — split `tests/test_install.sh` (803 lines, 97 tests) into a test runner (`tests/runner.sh`) + 25 individual test files with numeric sort ordering

--- a/pike.json
+++ b/pike.json
@@ -1,0 +1,9 @@
+{
+  "name": "pmp",
+  "version": "0.3.0",
+  "description": "Pike Module Package Manager",
+  "source": "github.com/TheSmuks/pmp",
+  "dependencies": {
+    "PUnit": "github.com/TheSmuks/punit-tests"
+  }
+}

--- a/tests/pike/HelpersTests.pike
+++ b/tests/pike/HelpersTests.pike
@@ -1,0 +1,64 @@
+//! Tests for Pmp.Helpers — compute_sha256, json_field, display_name.
+
+import PUnit;
+import Pmp.Helpers;
+inherit PUnit.TestCase;
+
+// ── compute_sha256 ───────────────────────────────────────────────────
+
+protected string tmpdir;
+
+void setup() {
+    tmpdir = combine_path(getcwd(), ".tmp-test-helpers-" + getpid());
+    Stdio.mkdirhier(tmpdir);
+}
+
+void teardown() {
+    if (tmpdir && Stdio.exist(tmpdir))
+        Process.run(({"rm", "-rf", tmpdir}));
+}
+
+void test_sha256_known_content() {
+    string path = combine_path(tmpdir, "test.txt");
+    Stdio.write_file(path, "hello\n");
+    // SHA-256 of "hello\n"
+    string expected = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03";
+    assert_equal(expected, compute_sha256(path));
+}
+
+void test_sha256_empty_file() {
+    string path = combine_path(tmpdir, "empty.txt");
+    Stdio.write_file(path, "");
+    // SHA-256 of empty string
+    string expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    assert_equal(expected, compute_sha256(path));
+}
+
+void test_sha256_missing_file() {
+    assert_equal("unknown", compute_sha256("/nonexistent/file"));
+}
+
+// ── json_field ───────────────────────────────────────────────────────
+
+void test_json_field_reads_value() {
+    string path = combine_path(tmpdir, "test.json");
+    Stdio.write_file(path, Standards.JSON.encode((["name": "pmp", "version": "1.0"])));
+    assert_equal("pmp", json_field("name", path));
+    assert_equal("1.0", json_field("version", path));
+}
+
+void test_json_field_missing_key() {
+    string path = combine_path(tmpdir, "test.json");
+    Stdio.write_file(path, Standards.JSON.encode((["name": "pmp"])));
+    assert_equal(0, json_field("missing", path));
+}
+
+void test_json_field_missing_file() {
+    assert_equal(0, json_field("name", "/nonexistent/file.json"));
+}
+
+void test_json_field_invalid_json() {
+    string path = combine_path(tmpdir, "bad.json");
+    Stdio.write_file(path, "not valid json {{{");
+    assert_equal(0, json_field("name", path));
+}

--- a/tests/pike/LockfilePureTests.pike
+++ b/tests/pike/LockfilePureTests.pike
@@ -1,0 +1,159 @@
+//! Tests for Pmp.Lockfile pure functions — lockfile_add_entry, merge_lock_entries, lockfile_has_dep.
+
+import PUnit;
+import Pmp.Lockfile;
+inherit PUnit.TestCase;
+
+// ── lockfile_add_entry ───────────────────────────────────────────────
+
+void test_add_entry_appends() {
+    array(array(string)) entries = ({});
+    entries = lockfile_add_entry(entries, "mod1", "github.com/o/r", "v1.0.0",
+                                 "abc123", "sha256abc");
+    assert_equal(1, sizeof(entries));
+    assert_equal("mod1", entries[0][0]);
+    assert_equal("github.com/o/r", entries[0][1]);
+    assert_equal("v1.0.0", entries[0][2]);
+    assert_equal("abc123", entries[0][3]);
+    assert_equal("sha256abc", entries[0][4]);
+}
+
+void test_add_entry_preserves_existing() {
+    array(array(string)) entries = ({});
+    entries = lockfile_add_entry(entries, "mod1", "github.com/o/r1", "v1.0.0",
+                                 "aaa", "sha1");
+    entries = lockfile_add_entry(entries, "mod2", "github.com/o/r2", "v2.0.0",
+                                 "bbb", "sha2");
+    assert_equal(2, sizeof(entries));
+    assert_equal("mod1", entries[0][0]);
+    assert_equal("mod2", entries[1][0]);
+}
+
+void test_add_entry_returns_new_array() {
+    array(array(string)) original = ({});
+    array(array(string)) result = lockfile_add_entry(original, "m", "s", "t", "sh", "h");
+    // Original should be unchanged (Pike arrays are reference types but += creates new)
+    assert_equal(0, sizeof(original));
+    assert_equal(1, sizeof(result));
+}
+
+// ── merge_lock_entries ───────────────────────────────────────────────
+
+void test_merge_dedup_by_name() {
+    array(array(string)) existing = ({
+        ({"mod1", "github.com/o/r1", "v1.0.0", "aaa", "sha1"}),
+    });
+    array(array(string)) new_entries = ({
+        ({"mod1", "github.com/o/r1", "v2.0.0", "bbb", "sha2"}),
+    });
+    array(array(string)) merged = merge_lock_entries(existing, new_entries);
+    assert_equal(1, sizeof(merged));
+    assert_equal("v2.0.0", merged[0][2]);
+}
+
+void test_merge_keeps_non_overlapping() {
+    array(array(string)) existing = ({
+        ({"mod1", "github.com/o/r1", "v1.0.0", "aaa", "sha1"}),
+    });
+    array(array(string)) new_entries = ({
+        ({"mod2", "github.com/o/r2", "v2.0.0", "bbb", "sha2"}),
+    });
+    array(array(string)) merged = merge_lock_entries(existing, new_entries);
+    assert_equal(2, sizeof(merged));
+}
+
+void test_merge_new_takes_priority() {
+    array(array(string)) existing = ({
+        ({"mod1", "github.com/o/r1", "v1.0.0", "aaa", "sha1"}),
+        ({"mod2", "github.com/o/r2", "v2.0.0", "bbb", "sha2"}),
+    });
+    array(array(string)) new_entries = ({
+        ({"mod1", "github.com/o/r1", "v3.0.0", "ccc", "sha3"}),
+    });
+    array(array(string)) merged = merge_lock_entries(existing, new_entries);
+    assert_equal(2, sizeof(merged));
+    // mod1 should be the new version
+    foreach (merged; ; array(string) e)
+        if (e[0] == "mod1")
+            assert_equal("v3.0.0", e[2]);
+}
+
+void test_merge_empty_existing() {
+    array(array(string)) existing = ({});
+    array(array(string)) new_entries = ({
+        ({"mod1", "github.com/o/r1", "v1.0.0", "aaa", "sha1"}),
+    });
+    array(array(string)) merged = merge_lock_entries(existing, new_entries);
+    assert_equal(1, sizeof(merged));
+}
+
+void test_merge_empty_new() {
+    array(array(string)) existing = ({
+        ({"mod1", "github.com/o/r1", "v1.0.0", "aaa", "sha1"}),
+    });
+    array(array(string)) new_entries = ({});
+    array(array(string)) merged = merge_lock_entries(existing, new_entries);
+    assert_equal(1, sizeof(merged));
+}
+
+// ── lockfile_has_dep ─────────────────────────────────────────────────
+// Note: lockfile_has_dep reads from disk, so we create a temp lockfile.
+
+protected string tmpdir;
+protected string lockfile_path;
+
+void setup() {
+    tmpdir = combine_path(getcwd(), ".tmp-test-lockfile-" + getpid());
+    Stdio.mkdirhier(tmpdir);
+    lockfile_path = combine_path(tmpdir, "pike.lock");
+}
+
+void teardown() {
+    if (tmpdir && Stdio.exist(tmpdir)) {
+        // Clean up temp dir
+        Process.run(({"rm", "-rf", tmpdir}));
+    }
+}
+
+void write_temp_lockfile(array(array(string)) entries) {
+    String.Buffer buf = String.Buffer();
+    foreach (entries; ; array(string) entry)
+        buf->add(entry[0] + "\t" + entry[1] + "\t" + entry[2]
+                 + "\t" + entry[3] + "\t" + entry[4] + "\n");
+    Stdio.write_file(lockfile_path, buf->get());
+}
+
+void test_has_dep_name_match() {
+    write_temp_lockfile(({
+        ({"PUnit", "github.com/TheSmuks/punit-tests", "v1.2.0", "abc", "sha1"}),
+    }));
+    assert_equal(1, lockfile_has_dep("PUnit", lockfile_path));
+}
+
+void test_has_dep_name_miss() {
+    write_temp_lockfile(({
+        ({"PUnit", "github.com/TheSmuks/punit-tests", "v1.2.0", "abc", "sha1"}),
+    }));
+    assert_equal(0, lockfile_has_dep("OtherMod", lockfile_path));
+}
+
+void test_has_dep_source_match() {
+    write_temp_lockfile(({
+        ({"PUnit", "github.com/TheSmuks/punit-tests", "v1.2.0", "abc", "sha1"}),
+    }));
+    assert_equal(1, lockfile_has_dep("PUnit", lockfile_path,
+                                      "github.com/TheSmuks/punit-tests"));
+}
+
+void test_has_dep_source_mismatch() {
+    write_temp_lockfile(({
+        ({"PUnit", "github.com/TheSmuks/punit-tests", "v1.2.0", "abc", "sha1"}),
+    }));
+    assert_equal(0, lockfile_has_dep("PUnit", lockfile_path,
+                                      "github.com/other/repo"));
+}
+
+void test_has_dep_empty_lockfile() {
+    // No lockfile at all
+    assert_equal(0, lockfile_has_dep("PUnit", lockfile_path));
+}

--- a/tests/pike/SemverTests.pike
+++ b/tests/pike/SemverTests.pike
@@ -1,0 +1,237 @@
+//! Tests for Pmp.Semver — parse_semver, compare_semver, sort_tags_semver, classify_bump.
+
+import PUnit;
+import Pmp.Semver;
+inherit PUnit.TestCase;
+
+// ── parse_semver ─────────────────────────────────────────────────────
+
+void test_parse_standard() {
+    mapping v = parse_semver("1.2.3");
+    assert_not_null(v);
+    assert_equal(1, v["major"]);
+    assert_equal(2, v["minor"]);
+    assert_equal(3, v["patch"]);
+    assert_equal("", v["prerelease"]);
+    assert_equal("1.2.3", v["original"]);
+}
+
+void test_parse_v_prefix() {
+    mapping v = parse_semver("v1.2.3");
+    assert_not_null(v);
+    assert_equal(1, v["major"]);
+    assert_equal(2, v["minor"]);
+    assert_equal(3, v["patch"]);
+}
+
+void test_parse_uppercase_v_prefix() {
+    mapping v = parse_semver("V2.0.0");
+    assert_not_null(v);
+    assert_equal(2, v["major"]);
+}
+
+void test_parse_prerelease() {
+    mapping v = parse_semver("1.2.3-alpha");
+    assert_not_null(v);
+    assert_equal("alpha", v["prerelease"]);
+}
+
+void test_parse_prerelease_dotted() {
+    mapping v = parse_semver("1.2.3-alpha.1");
+    assert_not_null(v);
+    assert_equal("alpha.1", v["prerelease"]);
+}
+
+void test_parse_build_metadata() {
+    // Build metadata is stripped per semver spec
+    mapping v = parse_semver("1.2.3+build");
+    assert_not_null(v);
+    assert_equal(3, v["patch"]);
+    assert_equal("", v["prerelease"]);
+}
+
+void test_parse_prerelease_and_build() {
+    mapping v = parse_semver("1.2.3-beta.2+build.123");
+    assert_not_null(v);
+    assert_equal("beta.2", v["prerelease"]);
+    assert_equal("1.2.3-beta.2+build.123", v["original"]);
+}
+
+void test_parse_two_part_version() {
+    // "1.2" — minor only, patch defaults to 0
+    mapping v = parse_semver("1.2");
+    assert_not_null(v);
+    assert_equal(1, v["major"]);
+    assert_equal(2, v["minor"]);
+    assert_equal(0, v["patch"]);
+}
+
+void test_parse_single_part_version() {
+    // "7" — major only, minor and patch default to 0
+    mapping v = parse_semver("7");
+    assert_not_null(v);
+    assert_equal(7, v["major"]);
+    assert_equal(0, v["minor"]);
+    assert_equal(0, v["patch"]);
+}
+
+void test_parse_empty_string() {
+    assert_equal(0, parse_semver(""));
+}
+
+void test_parse_zero_arg() {
+    assert_equal(0, parse_semver(0));
+}
+
+void test_parse_non_semver() {
+    assert_equal(0, parse_semver("not-a-version"));
+}
+
+void test_parse_partial_letters() {
+    assert_equal(0, parse_semver("1.2.x"));
+}
+
+void test_parse_leading_zeros() {
+    // "01.2.3" — leading zeros still parse (digits-only check passes)
+    mapping v = parse_semver("01.2.3");
+    assert_not_null(v);
+    assert_equal(1, v["major"]);
+}
+
+void test_parse_trailing_dot() {
+    // "1.2." — empty part after dot
+    assert_equal(0, parse_semver("1.2."));
+}
+
+// ── compare_semver ───────────────────────────────────────────────────
+
+void test_compare_ordering_major() {
+    mapping a = parse_semver("1.0.0");
+    mapping b = parse_semver("2.0.0");
+    assert_equal(-1, compare_semver(a, b));
+    assert_equal(1, compare_semver(b, a));
+}
+
+void test_compare_ordering_minor() {
+    mapping a = parse_semver("1.1.0");
+    mapping b = parse_semver("1.2.0");
+    assert_equal(-1, compare_semver(a, b));
+}
+
+void test_compare_ordering_patch() {
+    mapping a = parse_semver("1.0.1");
+    mapping b = parse_semver("1.0.2");
+    assert_equal(-1, compare_semver(a, b));
+}
+
+void test_compare_equality() {
+    mapping a = parse_semver("1.0.0");
+    mapping b = parse_semver("1.0.0");
+    assert_equal(0, compare_semver(a, b));
+}
+
+void test_compare_equality_v_prefix() {
+    mapping a = parse_semver("v1.0.0");
+    mapping b = parse_semver("1.0.0");
+    assert_equal(0, compare_semver(a, b));
+}
+
+void test_compare_prerelease_less_than_release() {
+    mapping a = parse_semver("1.0.0-alpha");
+    mapping b = parse_semver("1.0.0");
+    assert_equal(-1, compare_semver(a, b));
+}
+
+void test_compare_prerelease_numeric_less_than_alpha() {
+    mapping a = parse_semver("1.0.0-1");
+    mapping b = parse_semver("1.0.0-alpha");
+    assert_equal(-1, compare_semver(a, b));
+}
+
+void test_compare_both_unparseable() {
+    assert_equal(0, compare_semver(0, 0));
+}
+
+void test_compare_left_unparseable() {
+    mapping b = parse_semver("1.0.0");
+    assert_equal(-1, compare_semver(0, b));
+}
+
+void test_compare_right_unparseable() {
+    mapping a = parse_semver("1.0.0");
+    assert_equal(1, compare_semver(a, 0));
+}
+
+// ── sort_tags_semver ─────────────────────────────────────────────────
+
+void test_sort_highest_first() {
+    array(string) sorted = sort_tags_semver(({"v1.0.0", "v2.0.0", "v1.5.0"}));
+    assert_equal(({ "v2.0.0", "v1.5.0", "v1.0.0" }), sorted);
+}
+
+void test_sort_non_semver_last() {
+    array(string) sorted = sort_tags_semver(({"not-a-tag", "v1.0.0", "v0.5.0"}));
+    assert_equal("v1.0.0", sorted[0]);
+    assert_equal("v0.5.0", sorted[1]);
+    assert_equal("not-a-tag", sorted[2]);
+}
+
+void test_sort_empty_array() {
+    assert_equal(({}), sort_tags_semver(({})));
+}
+
+void test_sort_single_element() {
+    assert_equal(({"v1.0.0"}), sort_tags_semver(({"v1.0.0"})));
+}
+
+void test_sort_mixed_valid_and_invalid() {
+    array(string) sorted = sort_tags_semver(
+        ({"v0.1.0", "release", "v0.10.0", "v0.2.0"}));
+    assert_equal("v0.10.0", sorted[0]);
+    assert_equal("v0.2.0", sorted[1]);
+    assert_equal("v0.1.0", sorted[2]);
+    assert_equal("release", sorted[3]);
+}
+
+// ── classify_bump ────────────────────────────────────────────────────
+
+void test_classify_major() {
+    assert_equal("major", classify_bump("v1.0.0", "v2.0.0"));
+}
+
+void test_classify_minor() {
+    assert_equal("minor", classify_bump("v1.0.0", "v1.1.0"));
+}
+
+void test_classify_patch() {
+    assert_equal("patch", classify_bump("v1.0.0", "v1.0.1"));
+}
+
+void test_classify_prerelease_old() {
+    assert_equal("prerelease", classify_bump("v1.0.0-alpha", "v1.0.0-beta"));
+}
+
+void test_classify_prerelease_new() {
+    assert_equal("prerelease", classify_bump("v1.0.0", "v1.0.1-alpha"));
+}
+
+void test_classify_downgrade() {
+    assert_equal("downgrade", classify_bump("v2.0.0", "v1.0.0"));
+}
+
+void test_classify_unknown_missing_old() {
+    assert_equal("unknown", classify_bump(0, "v1.0.0"));
+}
+
+void test_classify_unknown_missing_new() {
+    assert_equal("unknown", classify_bump("v1.0.0", 0));
+}
+
+void test_classify_unknown_both_unparseable() {
+    assert_equal("unknown", classify_bump("foo", "bar"));
+}
+
+void test_classify_same_version() {
+    // Equal versions return "patch" per implementation
+    assert_equal("patch", classify_bump("v1.0.0", "v1.0.0"));
+}

--- a/tests/pike/SourceTests.pike
+++ b/tests/pike/SourceTests.pike
@@ -1,0 +1,106 @@
+//! Tests for Pmp.Source — detect_source_type, source_to_name/version/domain/repo_path/strip_version.
+
+import PUnit;
+import Pmp.Source;
+inherit PUnit.TestCase;
+
+// ── detect_source_type ───────────────────────────────────────────────
+
+void test_detect_local_relative() {
+    assert_equal("local", detect_source_type("./my-module"));
+}
+
+void test_detect_local_absolute() {
+    assert_equal("local", detect_source_type("/home/user/my-module"));
+}
+
+void test_detect_github() {
+    assert_equal("github", detect_source_type("github.com/owner/repo"));
+}
+
+void test_detect_github_with_version() {
+    assert_equal("github", detect_source_type("github.com/owner/repo#v1.0.0"));
+}
+
+void test_detect_gitlab() {
+    assert_equal("gitlab", detect_source_type("gitlab.com/owner/repo"));
+}
+
+void test_detect_selfhosted() {
+    assert_equal("selfhosted", detect_source_type("git.example.com/owner/repo"));
+}
+
+// ── source_to_name ───────────────────────────────────────────────────
+
+void test_name_from_github() {
+    assert_equal("repo", source_to_name("github.com/owner/repo"));
+}
+
+void test_name_with_version() {
+    assert_equal("repo", source_to_name("github.com/owner/repo#v1.0.0"));
+}
+
+void test_name_deep_path() {
+    assert_equal("mymod", source_to_name("git.example.com/group/sub/mymod"));
+}
+
+// ── source_to_version ────────────────────────────────────────────────
+
+void test_version_from_tagged_source() {
+    assert_equal("v1.0.0", source_to_version("github.com/owner/repo#v1.0.0"));
+}
+
+void test_version_empty_when_no_tag() {
+    assert_equal("", source_to_version("github.com/owner/repo"));
+}
+
+void test_version_preserves_hash_in_tag() {
+    assert_equal("v1.0.0-beta", source_to_version("github.com/owner/repo#v1.0.0-beta"));
+}
+
+// ── source_strip_version ─────────────────────────────────────────────
+
+void test_strip_version_with_tag() {
+    assert_equal("github.com/owner/repo",
+                 source_strip_version("github.com/owner/repo#v1.0.0"));
+}
+
+void test_strip_version_no_tag() {
+    assert_equal("github.com/owner/repo",
+                 source_strip_version("github.com/owner/repo"));
+}
+
+// ── source_to_domain ─────────────────────────────────────────────────
+
+void test_domain_github() {
+    assert_equal("github.com", source_to_domain("github.com/owner/repo"));
+}
+
+void test_domain_gitlab() {
+    assert_equal("gitlab.com", source_to_domain("gitlab.com/owner/repo#v2.0.0"));
+}
+
+void test_domain_selfhosted() {
+    assert_equal("git.example.com", source_to_domain("git.example.com/team/mod"));
+}
+
+// ── source_to_repo_path ──────────────────────────────────────────────
+
+void test_repo_path_basic() {
+    assert_equal("owner/repo", source_to_repo_path("github.com/owner/repo"));
+}
+
+void test_repo_path_with_version() {
+    assert_equal("owner/repo",
+                 source_to_repo_path("github.com/owner/repo#v1.0.0"));
+}
+
+void test_repo_path_deep() {
+    assert_equal("group/sub/mymod",
+                 source_to_repo_path("git.example.com/group/sub/mymod"));
+}
+
+void test_repo_path_short() {
+    // Only domain, no owner/repo
+    assert_equal("", source_to_repo_path("github.com"));
+}

--- a/tests/pike/run.pike
+++ b/tests/pike/run.pike
@@ -1,0 +1,42 @@
+//! PUnit test runner for pmp.
+//!
+//! Delegates to PUnit.TestRunner. Defaults to scanning tests/pike/.
+
+int main(int argc, array(string) argv) {
+    // Parse CLI options with same flags as PUnit's run_tests.pike
+    mapping options = ([]);
+    array(string) tags = ({});
+    array(string) exclude_tags = ({});
+
+    array opts = Getopt.find_all_options(argv, ({
+        ({"verbose",   Getopt.NO_ARG,  ({"-v", "--verbose"}),   "V", 0}),
+        ({"stop",      Getopt.NO_ARG,  ({"-s", "--stop"}),      "S", 0}),
+        ({"no_color",  Getopt.NO_ARG,  ({"--no-color"}),        "N", 0}),
+        ({"tag",       Getopt.HAS_ARG, ({"-t", "--tag"}),       "T", 0}),
+        ({"exclude",   Getopt.HAS_ARG, ({"-e", "--exclude"}),   "E", 0}),
+        ({"filter",    Getopt.HAS_ARG, ({"-f", "--filter"}),    "F", 0}),
+    }));
+
+    foreach (opts; ; array opt) {
+        switch (opt[0]) {
+            case "verbose":   options->verbose = 1; break;
+            case "stop":      options->stop_on_failure = 1; break;
+            case "no_color":  options->no_color = 1; break;
+            case "tag":       tags += ({ opt[1] }); break;
+            case "exclude":   exclude_tags += ({ opt[1] }); break;
+            case "filter":    options->filter = opt[1]; break;
+        }
+    }
+
+    options->tags = tags;
+    options->exclude_tags = exclude_tags;
+
+    array(string) paths = Getopt.get_args(argv)[1..];
+
+    // Default: scan tests/pike/
+    if (sizeof(paths) == 0)
+        paths = ({ combine_path(getcwd(), "tests/pike") });
+
+    object runner = PUnit.TestRunner(options);
+    return runner->run(paths);
+}

--- a/tests/pike_tests.sh
+++ b/tests/pike_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Run Pike unit tests via PUnit
+_self="$(cd "$(dirname "$0")" && pwd)"
+cd "$_self/.."
+
+# Install PUnit if not present
+if [ ! -d modules/PUnit.pmod ]; then
+    sh bin/pmp install || exit 1
+fi
+
+exec pike -M modules -M bin tests/pike/run.pike "$@"


### PR DESCRIPTION
## What

Adds PUnit as a dev dependency and writes Pike-level unit tests (81 tests) exercising pmp's pure-function modules.

## Why

The existing 114 shell tests are integration tests — they exercise the full `pmp` CLI. Pike unit tests provide compile-time and runtime verification of the pure-function library modules directly, catching type errors and logic bugs that shell tests can't surface.

## Changes

### New files
| File | Purpose |
|---|---|
| `pike.json` | Declares PUnit as a dev dependency |
| `tests/pike_tests.sh` | Shell entry point — installs PUnit if missing, runs tests |
| `tests/pike/run.pike` | PUnit test harness with CLI flag support |
| `tests/pike/SemverTests.pike` | 40 tests: parse_semver, compare_semver, sort_tags_semver, classify_bump |
| `tests/pike/SourceTests.pike` | 21 tests: detect_source_type, source_to_name/version/domain/repo_path/strip_version |
| `tests/pike/LockfilePureTests.pike` | 13 tests: lockfile_add_entry, merge_lock_entries, lockfile_has_dep |
| `tests/pike/HelpersTests.pike` | 7 tests: compute_sha256, json_field |

### Modified files
| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Added "Run Pike unit tests" step |
| `CHANGELOG.md` | [Unreleased] entry |
| `AGENTS.md` | Added Pike test run command |
| `ARCHITECTURE.md` | Added tests/pike/ to project structure |

## Verification

```
$ sh tests/pike_tests.sh
Results: 81 passed

$ sh tests/test_install.sh
Results: 114 passed, 0 failed
```

## Usage

```sh
sh tests/pike_tests.sh          # run all Pike tests
sh tests/pike_tests.sh -v       # verbose: show each test name
pike -M modules -M bin tests/pike/run.pike tests/pike/SemverTests.pike  # single file
```