### PR TITLE
fix(http): follow HTTP 3xx redirects

### DIFF
--- a/bin/Pmp.pmod/Http.pmod
+++ b/bin/Pmp.pmod/Http.pmod
@@ -5,7 +5,6 @@ inherit .Helpers;
 string http_get(string url, void|mapping(string:string) headers,
                 void|string version) {
     version = version || "0.2.0";
-    Protocols.HTTP.Query con;
     mapping request_headers = ([
         "user-agent": "pmp/" + version,
     ]);
@@ -13,31 +12,44 @@ string http_get(string url, void|mapping(string:string) headers,
     if (headers)
         request_headers |= headers;
 
-    mixed err = catch {
-        con = Protocols.HTTP.do_method("GET", url, 0, request_headers);
-    };
+    // Follow up to 5 HTTP 3xx redirects
+    int max_redirects = 5;
+    for (int i = 0; i <= max_redirects; i++) {
+        Protocols.HTTP.Query con;
+        mixed err = catch {
+            con = Protocols.HTTP.do_method("GET", url, 0, request_headers);
+        };
 
-    if (err) {
-        die("failed to fetch " + url + ": " + describe_error(err));
+        if (err)
+            die("failed to fetch " + url + ": " + describe_error(err));
+        if (!con)
+            die("failed to connect to " + url);
+
+        // Handle redirects
+        if (con->status >= 300 && con->status < 400) {
+            string location = con->headers["location"];
+            if (!location || sizeof(location) == 0)
+                die(sprintf("HTTP %d with no Location header fetching %s",
+                           con->status, url));
+            url = location;
+            continue;
+        }
+
+        if (con->status != 200)
+            die(sprintf("HTTP %d fetching %s", con->status, url));
+
+        string body = con->data();
+        if (!body)
+            die("no data from " + url);
+        return body;
     }
-    if (!con) {
-        die("failed to connect to " + url);
-    }
-    if (con->status != 200) {
-        die(sprintf("HTTP %d fetching %s", con->status, url));
-    }
-    string body = con->data();
-    if (!body) {
-        die("no data from " + url);
-    }
-    return body;
+
+    die("too many redirects fetching " + url);
 }
 
-//! HTTP GET returning ({status, body}) — doesn't die on non-200.
 array(int|string) http_get_safe(string url, void|mapping(string:string) headers,
                                  void|string version) {
     version = version || "0.2.0";
-    Protocols.HTTP.Query con;
     mapping request_headers = ([
         "user-agent": "pmp/" + version,
     ]);
@@ -45,15 +57,31 @@ array(int|string) http_get_safe(string url, void|mapping(string:string) headers,
     if (headers)
         request_headers |= headers;
 
-    mixed err = catch {
-        con = Protocols.HTTP.do_method("GET", url, 0, request_headers);
-    };
+    // Follow up to 5 HTTP 3xx redirects
+    int max_redirects = 5;
+    for (int i = 0; i <= max_redirects; i++) {
+        Protocols.HTTP.Query con;
+        mixed err = catch {
+            con = Protocols.HTTP.do_method("GET", url, 0, request_headers);
+        };
 
-    if (err || !con)
-        return ({ 0, "" });
+        if (err || !con)
+            return ({ 0, "" });
 
-    string body = con->data() || "";
-    return ({ con->status, body });
+        // Handle redirects
+        if (con->status >= 300 && con->status < 400) {
+            string location = con->headers["location"];
+            if (!location || sizeof(location) == 0)
+                return ({ con->status, "" });
+            url = location;
+            continue;
+        }
+
+        string body = con->data() || "";
+        return ({ con->status, body });
+    }
+
+    return ({ 0, "" });
 }
 
 //! Build auth headers if GITHUB_TOKEN is set.


### PR DESCRIPTION
## Problem

CI fails on the "Run Pike unit tests" step because `pmp install` downloads from GitHub archive URLs, which redirect from `github.com` to `codeload.github.com` (HTTP 302). Both `http_get()` and `http_get_safe()` treated any non-200 status as fatal.

## Fix

Both functions now follow up to 5 HTTP 3xx redirects before giving up. This was claimed in the CHANGELOG as already fixed but the implementation was missing from `Http.pmod`.

## Verification

- `sh tests/pike_tests.sh` — 81 passed
- `sh tests/test_install.sh` — 114 passed, 0 failed