### PR TITLE
fix(store): replace broken String.Buffer chain in store_entry_name

### DIFF
--- a/bin/Pmp.pmod/Store.pmod
+++ b/bin/Pmp.pmod/Store.pmod
@@ -7,10 +7,8 @@ inherit .Resolve;
 string store_entry_name(string src, string tag, string sha) {
     string clean = (src / "#")[0];
     // Convert / to -, remove leading/trailing -
-    string slug = replace(clean, "/", "-");
-    slug = String.Buffer()->add(
-        replace(sprintf("%s", slug),
-                (["//": "-", "--": "-"])))->get();
+    // Convert / to -, collapse repeated dashes
+    string slug = replace(replace(clean, "/", "-"), "--", "-");
     // Trim leading/trailing dashes
     while (has_prefix(slug, "-")) slug = slug[1..];
     while (has_suffix(slug, "-")) slug = slug[..<1];


### PR DESCRIPTION
## Problem

`store_entry_name()` uses `String.Buffer()->add(...)->get()`, but `add()` returns the number of bytes written (an `int`), not the buffer object. Calling `->get()` on that integer fails:

```
Indexing the integer 31 with unknown method "get".
```

This crashes `pmp install` for any GitHub dependency.

## Fix

Replace the `String.Buffer` chain with simple nested `replace()` calls — the same result without the broken method chaining.