### PR TITLE
fix(ci): remove deleted bak-lib from pike.json

### DIFF
--- a/pike.json
+++ b/pike.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "punit-tests": "github.com/TheSmuks/punit-tests",
-    "bak-lib": "./libs/bak-lib"
+    "punit-tests": "github.com/TheSmuks/punit-tests"
   },
   "name": "test"
 }


### PR DESCRIPTION
## Problem

CI `pike_tests.sh` fails with `resolvepath(): File not found` because `pike.json` still references `./libs/bak-lib` as a local dependency, but that directory was deleted in the audit remediation PR (#14).

## Fix

Remove the `"bak-lib": "./libs/bak-lib"` entry from `pike.json`.

## Verification

- `sh bin/pmp install` succeeds with the updated `pike.json`
- `sh tests/pike_tests.sh` passes: 330 tests, 0 failures