### PR TITLE
fix(tests): replace PUnit-specific symlink with generic store traversal

### DIFF
--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -110,22 +110,19 @@ restore_store() {
             mv "$_PMP_STORE_BACKUP/store" "${HOME:-/tmp}/.pike/store"
         fi
     fi
-    # Recreate modules/ directory and PUnit symlink if store is non-empty but modules/ is missing.
-    # Some tests end with `cd /` so we need to cd to the project dir.
     _proj_root=$(cd "$(dirname "$PMP")/.." && pwd)
     if [ -d "${HOME:-/tmp}/.pike/store" ] && [ -n "$(ls -A "${HOME:-/tmp}/.pike/store" 2>/dev/null)" ]; then
-        if ! [ -e "$_proj_root/modules/PUnit.pmod" ]; then
-            # Create modules/ dir and symlink PUnit directly from the store.
-            # This avoids calling `pmp install` which requires network.
-            mkdir -p "$_proj_root/modules"
-            # Find the PUnit store entry (punit-tests repo)
-            for _entry in "${HOME:-/tmp}/.pike/store"/*; do
-                if [ -d "$_entry/PUnit.pmod" ]; then
-                    ln -sf "$_entry/PUnit.pmod" "$_proj_root/modules/PUnit.pmod"
-                    break
-                fi
+mkdir -p "$_proj_root/modules"
+        # Symlink every .pmod directory found in the store.
+        # Generic approach — no hard-coded module names.
+        for _entry in "${HOME:-/tmp}/.pike/store"/*; do
+            [ -d "$_entry" ] || continue
+            for _pmod in "$_entry"/*.pmod; do
+                [ -d "$_pmod" ] || continue
+                _pmod_name=$(basename "$_pmod")
+                ln -sf "$_pmod" "$_proj_root/modules/$_pmod_name"
             done
-        fi
+        done
     fi
     [ -n "$_PMP_STORE_BACKUP" ] && rm -rf "$_PMP_STORE_BACKUP"
     unset _PMP_STORE_BACKUP _STORE_HAD_CONTENT


### PR DESCRIPTION
## Summary

Fixes Issue #25: `restore_store()` in `tests/helpers.sh` hard-coded the PUnit module name. If pmp's dependencies change, the test harness breaks.

## Changes

**tests/helpers.sh**:
- Replaced PUnit-specific loop with generic approach
- Now iterates all store entries and symlinks any `*.pmod` directory found
- No hard-coded module names, no lockfile parsing, no assumptions about which modules are installed

## Before/After

**Before**: Only symlinked `PUnit.pmod` if it existed
**After**: Symlinks every `.pmod` directory from every store entry

## Testing

- `sh tests/test_install.sh`: 211 passed, 0 failed
- `sh tests/pike_tests.sh`: All checks passed

## Related

- Fixes #25