### PR TITLE
test(ci): add install script tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ jobs:
       - name: Verify Pike
         run: pike --version
 
+      - name: Test install script with version pin
+        run: |
+          TMPDIR=$(mktemp -d)
+          PMP_VERSION=v0.4.0 PMP_INSTALL_DIR="$TMPDIR/pmp" sh install.sh
+          "$TMPDIR/pmp/bin/pmp" version
+          rm -rf "$TMPDIR"
+      - name: Test install script without version pin
+        run: |
+          TMPDIR=$(mktemp -d)
+          PMP_INSTALL_DIR="$TMPDIR/pmp-latest" sh install.sh
+          "$TMPDIR/pmp-latest/bin/pmp" --version
+          rm -rf "$TMPDIR"
       - name: Run shell tests
         run: sh tests/test_install.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 9co|
 10ke|### Fixed
 11ke|fix(docs): corrected AGENTS.md line counts (Verify ~269, Update ~210, LockOps ~281) and total source (~4825)
-fix(install): install.sh now uses `^{commit}` to dereference annotated tags during version verification — prevents false checksum mismatch on annotated tag checkouts
+11ke|fix(install): install.sh now uses `^{commit}` to dereference annotated tags during version verification — prevents false checksum mismatch on annotated tag checkouts
 12ke|fix(docs): corrected ARCHITECTURE.md line counts (pmp.pike ~274, Install.pmod ~582)
 13ke|fix(docs): updated AGENTS.md and ARCHITECTURE.md shell test count to 211 (were 172 in ARCHITECTURE.md)
 14ke|fix(docs): updated install.sh and README.md version examples to v0.4.0


### PR DESCRIPTION
## Summary

Add install script tests to CI to prevent regression of issue #29.

## Changes

Added two CI steps after "Verify Pike":
1. **Test install script with version pin** — Tests that `PMP_VERSION=v0.4.0 sh install.sh` works, exercising the annotated tag SHA fix
2. **Test install script without version pin** — Tests that `sh install.sh` (without version pin) installs the latest version

Both tests:
- Use temporary directories that are cleaned up
- Verify the installed `pmp` binary works