### PR TITLE
fix(ci): restore project root state after shell tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,30 +26,19 @@ jobs:
           PMP_VERSION=v0.4.0 PMP_INSTALL_DIR="$TMPDIR/pmp" sh install.sh
           "$TMPDIR/pmp/bin/pmp" version
           rm -rf "$TMPDIR"
+
       - name: Test install script without version pin
         run: |
           TMPDIR=$(mktemp -d)
           PMP_INSTALL_DIR="$TMPDIR/pmp-latest" sh install.sh
           "$TMPDIR/pmp-latest/bin/pmp" --version
           rm -rf "$TMPDIR"
+
       - name: Run shell tests
         run: sh tests/test_install.sh
 
       - name: Install Pike modules (PUnit)
-        run: |
-          # Clear store to avoid stale entries from previous runs
-          rm -rf ~/.pike/store
-          mkdir -p ~/.pike/store
-          sh bin/pmp install
-          # Verify PUnit is loadable
-          pike -M modules -e 'import PUnit; write("PUnit OK\\n");'
+        run: sh bin/pmp install
 
       - name: Run Pike unit tests
-        run: |
-          # Ensure modules are still available (race condition mitigation)
-          if [ ! -e "modules/PUnit.pmod" ]; then
-            echo "PUnit missing, reinstalling..."
-            sh bin/pmp install
-          fi
-          ls -la modules/
-          sh tests/pike_tests.sh || { echo "Retrying..."; sleep 5; sh tests/pike_tests.sh; }
+        run: sh tests/pike_tests.sh

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -21,6 +21,7 @@ cleanup() {
   cd /
   [ -n "$TESTDIR" ] && rm -rf "$TESTDIR"
   restore_store
+  restore_project_root
   for _td in $_TRACKED_TEMPDIRS; do
     [ -d "$_td" ] && rm -rf "$_td"
   done
@@ -85,7 +86,6 @@ assert_output_contains() {
   esac
 }
 
-
 # ── Store backup ─────────────────────────────────────────────────
 
 # Backup the real store before tests that might modify it
@@ -112,7 +112,7 @@ restore_store() {
     fi
     _proj_root=$(cd "$(dirname "$PMP")/.." && pwd)
     if [ -d "${HOME:-/tmp}/.pike/store" ] && [ -n "$(ls -A "${HOME:-/tmp}/.pike/store" 2>/dev/null)" ]; then
-mkdir -p "$_proj_root/modules"
+        mkdir -p "$_proj_root/modules"
         # Symlink every .pmod directory found in the store.
         # Generic approach — no hard-coded module names.
         for _entry in "${HOME:-/tmp}/.pike/store"/*; do
@@ -129,6 +129,45 @@ mkdir -p "$_proj_root/modules"
     # Also clean up any test-specific backup (test_10_store.sh etc.)
     [ -n "$_STORE_BACKUP" ] && rm -rf "$_STORE_BACKUP"
     unset _STORE_BACKUP
+}
+
+# ── Project root restore ─────────────────────────────────────────
+
+restore_project_root() {
+    # Restore the project root's pike.json, pike.lock, and remove test-created
+    # modules/libs/ directories.
+    if [ -z "$_PROJ_ROOT" ]; then
+        _PROJ_ROOT=$(cd "$(dirname "$PMP")/.." && pwd)
+    fi
+
+    # Restore pike.json — prefer backup, else remove test-created file
+    if [ -n "$_PIKE_JSON_BACKUP" ] && [ -f "$_PIKE_JSON_BACKUP" ]; then
+        cat "$_PIKE_JSON_BACKUP" > "$_PROJ_ROOT/pike.json"
+        rm -f "$_PIKE_JSON_BACKUP"
+    elif [ -f "$_PROJ_ROOT/pike.json" ]; then
+        # No backup existed; remove test-created file
+        rm -f "$_PROJ_ROOT/pike.json"
+    fi
+
+    # Restore pike.lock — prefer backup, else remove only if we created it
+    if [ -n "$_PIKE_LOCK_BACKUP" ] && [ -f "$_PIKE_LOCK_BACKUP" ]; then
+        cat "$_PIKE_LOCK_BACKUP" > "$_PROJ_ROOT/pike.lock"
+        rm -f "$_PIKE_LOCK_BACKUP"
+    fi
+
+    # Remove pike.lock.prev as well
+    rm -f "$_PROJ_ROOT/pike.lock.prev"
+
+    # Remove test-created modules/ if it didn't exist before tests started
+    if [ "$_MODULES_EXISTED" = "0" ]; then
+        rm -rf "$_PROJ_ROOT/modules"
+    fi
+
+    # Remove test-created libs/
+    rm -rf "$_PROJ_ROOT/libs"
+
+    # Clean up exported variables
+    unset _PIKE_JSON_BACKUP _PIKE_LOCK_BACKUP _MODULES_EXISTED _PROJ_ROOT
 }
 
 # ── Temp dir tracking ──────────────────────────────────────────────

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -18,7 +18,6 @@ _TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Set up trap for cleanup
 trap cleanup EXIT
 
-
 # Derive module path from the PMP shim location
 _PMP_DIR="$(dirname "$PMP")"
 
@@ -43,6 +42,25 @@ if [ -d "${HOME:-/tmp}/.pike/store" ]; then
     cp -a "${HOME:-/tmp}/.pike/store" "$_PMP_STORE_BACKUP/store"
     export _PMP_STORE_BACKUP
 fi
+
+# Backup project root state that tests may modify.
+# Tests source into the same shell process; non-isolated tests can overwrite
+# pike.json, pike.lock, and create modules/libs/ in the project root.
+# cleanup() (in helpers.sh) restores these after all tests finish.
+_PROJ_ROOT="$(cd "$(dirname "$PMP")/.." && pwd)"
+_PIKE_JSON_BACKUP=""
+if [ -f "$_PROJ_ROOT/pike.json" ]; then
+    _PIKE_JSON_BACKUP=$(mktemp)
+    cat "$_PROJ_ROOT/pike.json" > "$_PIKE_JSON_BACKUP"
+fi
+_PIKE_LOCK_BACKUP=""
+if [ -f "$_PROJ_ROOT/pike.lock" ]; then
+    _PIKE_LOCK_BACKUP=$(mktemp)
+    cat "$_PROJ_ROOT/pike.lock" > "$_PIKE_LOCK_BACKUP"
+fi
+_MODULES_EXISTED=0
+[ -d "$_PROJ_ROOT/modules" ] && _MODULES_EXISTED=1
+export _PIKE_JSON_BACKUP _PIKE_LOCK_BACKUP _MODULES_EXISTED _PROJ_ROOT
 
 # ── Discover test files ───────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

CI fails on "Run Pike unit tests" with `Undefined identifier PUnit`. Tests pass locally because the store already has PUnit installed.

## Root Cause

The shell test runner sources test files into the same shell process. Non-isolated tests (22 of 36) run in the project root CWD and overwrite `pike.json` with test data without cleaning up. After all shell tests finish, the project root has a stale test `pike.json` with no `"punit-tests"` dependency. The CI step `sh bin/pmp install` reads this stale file, finds nothing to install, and PUnit is never installed.

## Fix

Mirror the existing store backup/restore pattern for project root files:

- **`tests/runner.sh`** — backup `pike.json`, `pike.lock`, and record `modules/` existence before tests start
- **`tests/helpers.sh`** — new `restore_project_root()` called from `cleanup()` to restore project root state after all tests finish
- **`.github/workflows/ci.yml`** — remove store-clearing workaround and retry logic (no longer needed)

## Verification

- Shell tests: 221 passed, 0 failed
- Pike tests: 321 passed
- `pike.json` identical to HEAD after shell tests
- `modules/PUnit.pmod` present for Pike test runner