### PR TITLE
docs(readme): add pmpx documentation, clean anchor artifacts, add corruption guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+# pre-commit hook: reject edit-tool anchor artifacts
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+if [ -n "$STAGED" ]; then
+    CORRUPT=$(echo "$STAGED" | xargs grep -l '[0-9][0-9][a-z][a-z]|' 2>/dev/null || true)
+    if [ -n "$CORRUPT" ]; then
+        echo "ERROR: edit-tool anchor artifacts found in staged files:"
+        for f in $CORRUPT; do
+            grep -n '[0-9][0-9][a-z][a-z]|' "$f"
+        done
+        echo ""
+        echo "These NNLL| prefixes are edit-tool artifacts, not content."
+        echo "Remove them before committing."
+        exit 1
+    fi
+fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,13 +4,13 @@
 
 - **Name**: pmp (Pike Module Package Manager)
 - **Repository**: github.com/TheSmuks/pmp
-- **Version**: 0.4.0
-- **Date**: 2026-04-30
+- **Version**: 0.5.0
+- **Date**: 2026-05-02
 ## Project Structure
 
 ```
 bin/pmp                POSIX sh shim — delegates to bin/pmp.pike, sets PIKE_MODULE_PATH
-13dk|bin/pmp.pike           Entry point (~274 lines) — config init, command dispatch
+bin/pmp.pike           Entry point (~274 lines) — config init, command dispatch
 bin/Pmp.pmod/          Flat module namespace (17 modules + namespace file)
   module.pmod          Namespace-only — no inherit re-exports; sub-modules accessed as Pmp.Config etc.
   Config.pmod          PMP_VERSION constant
@@ -37,7 +37,7 @@ bin/Pmp.pmod/          Flat module namespace (17 modules + namespace file)
   Env.pmod             cmd_env, cmd_resolve, cmd_run, build_paths
                        (virtual environment, path resolution, script execution)
   Install.pmod         install_one, cmd_install, cmd_install_all, cmd_install_source,
-40mi|                       project_lock/unlock (~582 lines)
+                       (~582 lines)
   Update.pmod          cmd_update (single-module and full update), cmd_outdated,
                        print_update_summary
   LockOps.pmod         cmd_lock, cmd_rollback, cmd_changelog
@@ -102,7 +102,7 @@ User → pmp CLI (bin/pmp shim → bin/pmp.pike)
 
 ## Core Components
 
-104kk|### bin/pmp.pike (entry point, ~274 lines)
+### bin/pmp.pike (entry point, ~274 lines)
 
 Holds all mutable state (`lock_entries`, `visited`, `std_libs`, config paths) and command dispatch. All pure functions are imported from `Pmp.pmod/` via explicit imports (`import Pmp.Config;`, `import Pmp.Helpers;`, etc.).
 
@@ -148,7 +148,7 @@ All modules are pure functions — no mutable global state. State is passed as e
 
 #### Install & update orchestrators
 
-150zd|- **Install.pmod** — `install_one`, `cmd_install`, `cmd_install_all`, `cmd_install_source`, `project_lock`/`project_unlock` (shared lock helpers, ~582 lines)
+- **Install.pmod** — `install_one`, `cmd_install`, `cmd_install_all`, `cmd_install_source` (~582 lines)
 - **Update.pmod** — `cmd_update` (single-module and full update with lock management), `cmd_outdated` (compares lockfile versions with latest remote tags), `print_update_summary`
 - **LockOps.pmod** — `cmd_lock` (resolve + write lockfile without installing), `cmd_rollback` (restore modules from pike.lock.prev), `cmd_changelog` (show commit log between versions via GitHub/GitLab compare APIs)
 - **Exec.pmod** — `cmd_pmpx` (download and execute remote module without installing), `_find_entry_point` (pike.json bin field, heuristic filenames, single .pike fallback, ~155 lines)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,18 @@ feat(cli): `pmpx` command — download and execute a Pike module without install
 test(cli): shell and Pike unit tests for pmpx (error paths, entry point resolution, cache reuse, no side effects)
 ### Fixed
 fix(docs): updated AGENTS.md and ARCHITECTURE.md for Exec.pmod (18 modules, ~4984 lines, test counts, function listing)
-11ke|fix(docs): corrected AGENTS.md line counts (Verify ~269, Update ~210, LockOps ~281) and total source (~4825)
-11ke|fix(install): install.sh now uses `^{commit}` to dereference annotated tags during version verification — prevents false checksum mismatch on annotated tag checkouts
-12ke|fix(docs): corrected ARCHITECTURE.md line counts (pmp.pike ~274, Install.pmod ~582)
-13ke|fix(docs): updated AGENTS.md and ARCHITECTURE.md shell test count to 211 (were 172 in ARCHITECTURE.md)
-14ke|fix(docs): updated install.sh and README.md version examples to v0.4.0
-15ke|fix(docs): updated Pike test file names in ARCHITECTURE.md (SourceAdversarialTests, LockfileAdversarialTests, HelpersAdversarialTests, etc.)
-16ke|fix(docs): updated Helpers.pmod function list in AGENTS.md (added atomic_symlink, atomic_write, validate_dep_name, advisory_lock/unlock, make_temp_dir, resolve_local_path, register/unregister_cleanup_dir, run_cleanup)
-17vv|fix(docs): updated Validate.pmod function list in AGENTS.md (added strip_comments_and_strings, init_std_libs)
-18jk|fix(docs): extended scripts/doc-sync-check.sh with line count consistency checks (Verify/Update/LockOps, pmp.pike, Install.pmod totals, shell test count match)
-18to|
-19rz|## [0.4.0] - 2026-05-01
+fix(docs): added pmpx to README.md; cleaned anchor artifacts; corrected Install.pmod listing; added corruption guard to doc-sync-check
+fix(docs): corrected AGENTS.md line counts (Verify ~269, Update ~210, LockOps ~281) and total source (~4825)
+fix(install): install.sh now uses `^{commit}` to dereference annotated tags during version verification — prevents false checksum mismatch on annotated tag checkouts
+fix(docs): corrected ARCHITECTURE.md line counts (pmp.pike ~274, Install.pmod ~582)
+fix(docs): updated AGENTS.md and ARCHITECTURE.md shell test count to 211 (were 172 in ARCHITECTURE.md)
+fix(docs): updated install.sh and README.md version examples to v0.4.0
+fix(docs): updated Pike test file names in ARCHITECTURE.md (SourceAdversarialTests, LockfileAdversarialTests, HelpersAdversarialTests, etc.)
+fix(docs): updated Helpers.pmod function list in AGENTS.md (added atomic_symlink, atomic_write, validate_dep_name, advisory_lock/unlock, make_temp_dir, resolve_local_path, register/unregister_cleanup_dir, run_cleanup)
+fix(docs): updated Validate.pmod function list in AGENTS.md (added strip_comments_and_strings, init_std_libs)
+fix(docs): extended scripts/doc-sync-check.sh with line count consistency checks (Verify/Update/LockOps, pmp.pike, Install.pmod totals, shell test count match)
+
+## [0.4.0] - 2026-05-01
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ wget -qO- https://github.com/TheSmuks/pmp/install.sh | sh
 Pin to a specific version:
 
 ```bash
-curl -LsSf https://github.com/TheSmuks/pmp/install.sh | env PMP_VERSION=v0.4.0 sh
+curl -LsSf https://github.com/TheSmuks/pmp/install.sh | env PMP_VERSION=v0.5.0 sh
 ```
 
 ### Environment variables
@@ -248,9 +248,33 @@ pmp version                                 Show pmp version
 pmp self-update                             Update pmp to the latest version
 pmp verify                                  Verify installed dependencies
 pmp doctor                                  Diagnose common project issues
+pmp pmpx <source> [-- args...]              Execute module without installing
 ```
 
 > **Note:** pmp uses [Semantic Versioning](https://semver.org/) for tag comparison. Only tags matching MAJOR.MINOR.PATCH (with optional `v` prefix and `-prerelease` suffix) are sorted correctly. Non-semver tags are deprioritized.
+
+## pmpx (one-shot execution)
+
+Download and execute a remote Pike module without installing it into your project. No `pike.json`, `modules/`, or `pike.lock` files are modified.
+
+```bash
+# Run the latest version of a module
+pmp pmpx github.com/owner/repo
+
+# Pin to a specific version
+pmp pmpx github.com/owner/repo#v1.0.0
+
+# Pass arguments to the executed module
+pmp pmpx github.com/owner/repo -- --verbose --output=json
+```
+
+**Entry point resolution** (in order):
+
+1. `pike.json` `"bin"` field (e.g. `{"bin": "cli.pike"}`)
+2. Heuristic filenames: `main.pike`, `cli.pike`, `cmd.pike`
+3. Single `.pike` file at the package root (unambiguous)
+
+The module is downloaded to the shared content-addressable store (`~/.pike/store/`) and reused on subsequent runs. Local paths are not supported — use `pmp install ./path` instead.
 
 ## Selective .h imports
 

--- a/scripts/doc-sync-check.sh
+++ b/scripts/doc-sync-check.sh
@@ -122,7 +122,7 @@ fi
 
 # Install.pmod line count (ARCHITECTURE.md section)
 INSTALL_ACTUAL=$(wc -l < "$REPO_ROOT/bin/Pmp.pmod/Install.pmod" 2>/dev/null || echo 0)
-INSTALL_CLAIM=$(grep 'project_lock' "$REPO_ROOT/ARCHITECTURE.md" | grep -o '~[0-9]\+' | head -1)
+INSTALL_CLAIM=$(grep 'Install\.pmod.*install_one' "$REPO_ROOT/ARCHITECTURE.md" | grep -o '~[0-9]\+' | head -1)
 if [ -n "$INSTALL_CLAIM" ]; then
     check_line_count "$INSTALL_ACTUAL" "$INSTALL_CLAIM" "ARCHITECTURE.md (Install.pmod)"
 fi
@@ -145,6 +145,15 @@ if [ -n "$AGENTS_SHELL" ] && [ -n "$ARCH_SHELL" ]; then
     fi
 fi
 
+# ── 10. No edit-tool anchor artifacts in tracked docs ───────────────
+ANCHOR_CORRUPT=$(grep -l '[0-9][0-9][a-z][a-z]|' \
+    ARCHITECTURE.md CHANGELOG.md AGENTS.md README.md 2>/dev/null || true)
+if [ -n "$ANCHOR_CORRUPT" ]; then
+    for f in $ANCHOR_CORRUPT; do
+        LINES=$(grep -c '[0-9][0-9][a-z][a-z]|' "$f")
+        ERRORS="${ERRORS}ERROR: $f has $LINES line(s) with edit-tool anchor artifacts (NNLL| pattern)\n"
+    done
+fi
 # ── Report ─────────────────────────────────────────────────────────
 if [ -n "$ERRORS" ]; then
     printf "$ERRORS"


### PR DESCRIPTION
## Summary

- **README.md**: Added `pmpx` to the commands table and a new `## pmpx (one-shot execution)` section with usage examples, entry point resolution rules, and local path limitation. Updated version pin example from `v0.4.0` to `v0.5.0`.
- **ARCHITECTURE.md**: Removed 4 edit-tool anchor artifacts (`NNLL|` pattern). Fixed Install.pmod listing — removed `project_lock`/`project_unlock` which belong to Helpers.pmod. Updated version to `0.5.0` and date to `2026-05-02`.
- **CHANGELOG.md**: Removed 11 anchor artifacts. Added Unreleased entry documenting the changes.
- **scripts/doc-sync-check.sh**: Added section 10 — detects `NNLL|` anchor artifacts in tracked docs and blocks CI. Updated Install.pmod line count grep (was keyed on `project_lock`, now uses `Install.pmod.*install_one`).
- **.githooks/pre-commit**: New checked-in hook that rejects staged files containing anchor artifacts. Local convenience; CI doc-sync-check is the enforcement layer.

## Verification

- `grep -c '[0-9][0-9][a-z][a-z]|' ARCHITECTURE.md CHANGELOG.md README.md AGENTS.md` → all return 0
- `sh scripts/doc-sync-check.sh .` → passes
- `sh bin/pmp --help` → syntax clean
- `.githooks/pre-commit` — syntax validated with `sh -n`, regex pattern tested