### PR TITLE
fix(install): resolve modules in src/ layout + add module_path field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ pmp (Pike Module Package Manager) installs, versions, and resolves dependencies 
 - Verify syntax: `pike bin/pmp.pike --help`
 - Check version: `pike bin/pmp.pike version` (or `sh bin/pmp version`)
 
-Expected result: 230 passed, 0 failed, exit code 0 (shell tests via `sh tests/runner.sh`); Pike unit tests exit 0 (via `sh tests/pike_tests.sh`).
+Expected result: 242 passed, 0 failed, exit code 0 (shell tests via `sh tests/runner.sh`); Pike unit tests exit 0 (via `sh tests/pike_tests.sh`).
 
 ## Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@ docs(readme): restructured README to Bun-style layout — key info up top, quick
 
 ### Fixed
 fix(ci): dep-update.yml install step uses `curl -LsSf <url> | sh` instead of `sh <url>` — `sh` cannot fetch URLs, causing `pmp: command not found` in downstream steps
+fix(install): `pmp install` now resolves modules in Cargo-style `src/` layout — packages with `src/PackageName.pmod/module.pmod` are correctly detected and symlinked. Also supports `"module_path"` field in pike.json for explicit declaration (equivalent to Cargo's `[lib] path`). Fixes broken imports for packages like pike-introspect that use non-root layout. Backward compatible with existing flat and nested layouts.
+

--- a/bin/Pmp.pmod/Exec.pmod
+++ b/bin/Pmp.pmod/Exec.pmod
@@ -134,7 +134,8 @@ void cmd_pmpx(array(string) args, mapping ctx) {
     string tmp_modules = combine_path(tmpdir, "modules");
     Stdio.mkdirhier(tmp_modules);
 
-    mapping rmp = resolve_module_path(name, entry_dir);
+    mapping rmp = resolve_module_path(name, entry_dir,
+        combine_path(entry_dir, "pike.json"));
     string link_path = combine_path(tmp_modules, rmp->link_name);
     symlink(rmp->target, link_path);
 

--- a/bin/Pmp.pmod/Install.pmod
+++ b/bin/Pmp.pmod/Install.pmod
@@ -58,7 +58,8 @@ void install_one(string name, string source, string target,
             if (!Stdio.is_dir(local_path))
                 die("local path not found: " + local_path);
 
-            mapping rmp = resolve_module_path(name, local_path);
+            mapping rmp = resolve_module_path(name, local_path,
+                combine_path(local_path, "pike.json"));
             string dest = combine_path(target, rmp->link_name);
             Stdio.mkdirhier(target);
             atomic_symlink(rmp->target, dest);
@@ -228,7 +229,8 @@ void install_one(string name, string source, string target,
                 if (Stdio.exist(old_link)) rm(old_link);
                 if (Stdio.exist(old_link_pmod)) rm(old_link_pmod);
             }
-            mapping rmp = resolve_module_path(resolved_name, entry_full);
+            mapping rmp = resolve_module_path(resolved_name, entry_full,
+                combine_path(entry_full, "pike.json"));
             dest = combine_path(target, rmp->link_name);
             atomic_symlink(rmp->target, dest);
 
@@ -315,7 +317,8 @@ void cmd_install_all(string target, mapping ctx) {
                             continue;
                         }
                         Stdio.mkdirhier(target);
-                        mapping rmp = resolve_module_path(ln, local_path);
+                        mapping rmp = resolve_module_path(ln, local_path,
+                            combine_path(local_path, "pike.json"));
                         string dest = combine_path(target, rmp->link_name);
                         atomic_symlink(rmp->target, dest);
                         info("linked " + ln + " -> " + rmp->target);
@@ -331,7 +334,8 @@ void cmd_install_all(string target, mapping ctx) {
                         // Validate that the store entry exists and has valid structure.
                         // resolve_module_path() checks for name.pmod/ or module.pmod inside
                         // entry_full. If neither exists, the lockfile entry is stale.
-                        mapping rmp = resolve_module_path(ln, entry_full);
+                        mapping rmp = resolve_module_path(ln, entry_full,
+                            combine_path(entry_full, "pike.json"));
                         if (!Stdio.exist(rmp->target)) {
                             info("lockfile entry for " + ln
                                  + " not in store (stale) — re-resolving");

--- a/bin/Pmp.pmod/LockOps.pmod
+++ b/bin/Pmp.pmod/LockOps.pmod
@@ -95,7 +95,8 @@ void cmd_rollback(mapping ctx) {
                              + " not found — skipping");
                         continue;
                     }
-                    mapping rmp = resolve_module_path(ln, local_path);
+                    mapping rmp = resolve_module_path(ln, local_path,
+                        combine_path(local_path, "pike.json"));
                     string dest_rm = combine_path(target, rmp->link_name);
                     // Remove complementary symlink variant
                     if (dest != dest_rm) {
@@ -121,7 +122,8 @@ void cmd_rollback(mapping ctx) {
                 }
 
                 string entry_full = combine_path(ctx["store_dir"], found_entry);
-                mapping rmp = resolve_module_path(ln, entry_full);
+                mapping rmp = resolve_module_path(ln, entry_full,
+                    combine_path(entry_full, "pike.json"));
                 string dest_rm = combine_path(target, rmp->link_name);
                 // Remove complementary symlink variant (bare vs .pmod)
                 if (dest != dest_rm) {

--- a/bin/Pmp.pmod/Store.pmod
+++ b/bin/Pmp.pmod/Store.pmod
@@ -208,7 +208,34 @@ string compute_dir_hash(string dir) {
 //!   2. Name.pmod/module.pmod — directory with .pmod suffix
 //! Bare directories (Name/) are NOT resolved by import, so we always
 //! use .pmod-suffixed symlinks when module.pmod exists.
-mapping resolve_module_path(string name, string entry_dir) {
+//! Supports optional `"module_path"` in pike.json for explicit declaration,
+//! and Cargo-style `src/` layout convention as fallback.
+mapping resolve_module_path(string name, string entry_dir,
+                            void|string pike_json_path) {
+    // 0. Check pike.json for explicit module_path declaration
+    if (stringp(pike_json_path) && Stdio.exist(pike_json_path)) {
+        mixed mp = json_field("module_path", pike_json_path);
+        if (stringp(mp) && sizeof(mp) > 0) {
+            // Validate: no leading slash, no path traversal, relative path only
+            if (!has_prefix(mp, "/") && !has_value(mp, "..") && mp[0] != '\0') {
+                string resolved = combine_path(entry_dir, mp);
+                // Must exist and must be within entry_dir (no escaping)
+                if ((Stdio.is_dir(resolved) || Stdio.exist(resolved))
+                    && has_prefix(resolved, entry_dir)) {
+                    debug("module_path declared: " + mp + " -> " + resolved);
+                    string link = has_suffix(name, ".pmod") ? name : name + ".pmod";
+                    return (["target": resolved, "link_name": link]);
+                } else {
+                    warn("pike.json module_path '" + mp
+                         + "' not found — falling back to scanning");
+                }
+            } else {
+                warn("pike.json module_path '" + mp
+                     + "' is invalid (absolute path or traversal) — falling back to scanning");
+            }
+        }
+    }
+
     // 1. name.pmod/ directory (e.g., PUnit.pmod/) — nested module
     string pmod_dir = combine_path(entry_dir, name + ".pmod");
     if (Stdio.is_dir(pmod_dir))
@@ -225,7 +252,27 @@ mapping resolve_module_path(string name, string entry_dir) {
     if (Stdio.exist(combine_path(entry_dir, "module.pmod")))
         return (["target": entry_dir, "link_name": name + ".pmod"]);
 
-    // 4. Fallback: symlink to entry root
+    // 4. src/name.pmod/ — Cargo-style convention (src/MyLib.pmod/module.pmod)
+    string src_named = combine_path(entry_dir, "src", name + ".pmod");
+    if (Stdio.is_dir(src_named))
+        return (["target": src_named, "link_name": name + ".pmod"]);
+
+    // 5. src/ with exactly one *.pmod/ directory — single-module Cargo layout
+    //    Only use if src/ exists and contains exactly one pmod directory.
+    string src_dir = combine_path(entry_dir, "src");
+    if (Stdio.is_dir(src_dir)) {
+        array(string) entries = get_dir(src_dir);
+        if (entries) {
+            array(string) pmod_dirs = filter(entries, lambda(string e) {
+                return Stdio.is_dir(combine_path(src_dir, e)) && has_suffix(e, ".pmod");
+            });
+            if (sizeof(pmod_dirs) == 1)
+                return (["target": combine_path(src_dir, pmod_dirs[0]),
+                         "link_name": name + ".pmod"]);
+        }
+    }
+
+    // 6. Fallback: symlink to entry root
     return (["target": entry_dir, "link_name": name]);
 }
 

--- a/tests/test_26_module_resolution.sh
+++ b/tests/test_26_module_resolution.sh
@@ -163,3 +163,194 @@ assert "list shows N3" "1" "$_has_n3"
 # Clean up
 rm -rf modules libs
 rm -f /tmp/test_nested.pike /tmp/test_flat.pike
+
+# ══════════════════════════════════════════════════════════════════════
+# NEW TESTS: src/ layout and module_path field
+# ══════════════════════════════════════════════════════════════════════
+
+# ── Test 8: Cargo-style src/ layout with name.pmod/ ─────────────────
+
+rm -rf modules libs
+mkdir -p libs/src-layout/src/PkgName.pmod
+cat > libs/src-layout/src/PkgName.pmod/module.pmod << 'PIKE'
+constant version = "1.0.0";
+PIKE
+
+cat > pike.json << 'JSON'
+{
+  "dependencies": {
+    "PkgName": "./libs/src-layout"
+  }
+}
+JSON
+
+"$PMP" install
+
+# The symlink should point into src/PkgName.pmod/
+assert_exists "PkgName.pmod symlink created" "modules/PkgName.pmod"
+_dest="$(readlink modules/PkgName.pmod 2>/dev/null || echo '')"
+case "$_dest" in
+  */src/PkgName.pmod) _src_ok=1 ;;
+  *) _src_ok=0 ;;
+esac
+assert "symlink targets src/PkgName.pmod" "1" "$_src_ok"
+
+# Verify import works
+cat > /tmp/test_src.pike << 'PIKE'
+import PkgName;
+int main() {
+    werror(PkgName.version + "\n");
+    return 0;
+}
+PIKE
+_out="$(PIKE_MODULE_PATH="$(pwd)/modules" pike /tmp/test_src.pike 2>&1 || true)"
+assert_output_contains "import PkgName works with src/ layout" "1.0.0" "$_out"
+
+# ── Test 9: src/ with single *.pmod/ auto-detection ─────────────────
+
+rm -rf modules libs
+mkdir -p libs/single-src/src/SingleMod.pmod
+cat > libs/single-src/src/SingleMod.pmod/module.pmod << 'PIKE'
+constant value = 99;
+PIKE
+
+cat > pike.json << 'JSON'
+{
+  "dependencies": {
+    "SingleMod": "./libs/single-src"
+  }
+}
+JSON
+
+"$PMP" install
+
+# Should auto-detect src/SingleMod.pmod/ since src/ has exactly one pmod dir
+assert_exists "SingleMod.pmod symlink created" "modules/SingleMod.pmod"
+_dest="$(readlink modules/SingleMod.pmod 2>/dev/null || echo '')"
+case "$_dest" in
+  */src/SingleMod.pmod) _single_src_ok=1 ;;
+  *) _single_src_ok=0 ;;
+esac
+assert "symlink targets src/SingleMod.pmod via auto-detect" "1" "$_single_src_ok"
+
+# Verify import
+cat > /tmp/test_single_src.pike << 'PIKE'
+import SingleMod;
+int main() {
+    werror((string)SingleMod.value + "\n");
+    return 0;
+}
+PIKE
+_out="$(PIKE_MODULE_PATH="$(pwd)/modules" pike /tmp/test_single_src.pike 2>&1 || true)"
+assert_output_contains "import SingleMod works with auto-detect" "99" "$_out"
+
+
+# ── Test 10: module_path field in pike.json ─────────────────────────
+
+rm -rf modules libs
+mkdir -p libs/explicit-path/deep/nested/ExplicitMod.pmod
+cat > libs/explicit-path/deep/nested/ExplicitMod.pmod/module.pmod << 'PIKE'
+constant msg = "explicit module_path works";
+PIKE
+
+cat > libs/explicit-path/pike.json << 'JSON'
+{
+  "name": "ExplicitMod",
+  "version": "0.1.0",
+  "module_path": "deep/nested/ExplicitMod.pmod"
+}
+JSON
+
+cat > pike.json << 'JSON'
+{
+  "dependencies": {
+    "ExplicitMod": "./libs/explicit-path"
+  }
+}
+JSON
+
+"$PMP" install
+
+# Symlink should point to deep/nested/ExplicitMod.pmod via module_path
+assert_exists "ExplicitMod.pmod symlink created" "modules/ExplicitMod.pmod"
+_dest="$(readlink modules/ExplicitMod.pmod 2>/dev/null || echo '')"
+case "$_dest" in
+  */deep/nested/ExplicitMod.pmod) _explicit_ok=1 ;;
+  *) _explicit_ok=0 ;;
+esac
+assert "symlink targets module_path declared path" "1" "$_explicit_ok"
+
+# Verify import works
+cat > /tmp/test_explicit.pike << 'PIKE'
+import ExplicitMod;
+int main() {
+    werror(ExplicitMod.msg + "\n");
+    return 0;
+}
+PIKE
+_out="$(PIKE_MODULE_PATH="$(pwd)/modules" pike /tmp/test_explicit.pike 2>&1 || true)"
+assert_output_contains "import ExplicitMod works via module_path" "explicit module_path works" "$_out"
+
+# ── Test 11: module_path with invalid path falls back to scanning ────
+
+rm -rf modules libs
+mkdir -p libs/fallback-test/FallbackMod.pmod
+cat > libs/fallback-test/FallbackMod.pmod/module.pmod << 'PIKE'
+constant data = "fallback data";
+PIKE
+
+# Declare a non-existent module_path — should warn and fall back
+cat > libs/fallback-test/pike.json << 'JSON'
+{
+  "name": "FallbackMod",
+  "version": "0.1.0",
+  "module_path": "does/not/exist"
+}
+JSON
+
+cat > pike.json << 'JSON'
+{
+  "dependencies": {
+    "FallbackMod": "./libs/fallback-test"
+  }
+}
+JSON
+
+"$PMP" install 2>&1 | grep -q "module_path.*not found\|module_path.*falling back" || true
+
+# Should still work via fallback scanning
+assert_exists "FallbackMod.pmod symlink created (fallback)" "modules/FallbackMod.pmod"
+_out="$(PIKE_MODULE_PATH="$(pwd)/modules" pike -e 'import FallbackMod; werror(FallbackMod.data + "\n");' 2>&1 || true)"
+assert_output_contains "import FallbackMod works via fallback" "fallback data" "$_out"
+
+# ── Test 12: module_path with path traversal is rejected ─────────────
+
+rm -rf modules libs
+mkdir -p libs/traversal-test/TravMod.pmod
+cat > libs/traversal-test/TravMod.pmod/module.pmod << 'PIKE'
+constant x = 1;
+PIKE
+
+cat > libs/traversal-test/pike.json << 'JSON'
+{
+  "name": "TravMod",
+  "module_path": "../../etc/passwd"
+}
+JSON
+
+cat > pike.json << 'JSON'
+{
+  "dependencies": {
+    "TravMod": "./libs/traversal-test"
+  }
+}
+JSON
+
+"$PMP" install 2>&1 | grep -q "module_path.*invalid\|module_path.*traversal\|module_path.*falling back" || true
+
+# Should fall back and still work
+assert_exists "TravMod.pmod symlink created (traversal blocked)" "modules/TravMod.pmod"
+
+# Clean up
+rm -rf modules libs
+rm -f /tmp/test_src.pike /tmp/test_single_src.pike /tmp/test_explicit.pike


### PR DESCRIPTION
## Summary

Fixes `pmp install` for packages that use non-root directory layouts (e.g., `src/PackageName.pmod/`). Previously, packages like `pike-introspect` were broken because `resolve_module_path()` only scanned the entry root.

## Changes

### `bin/Pmp.pmod/Store.pmod`
Extended `resolve_module_path()` with:
1. Optional `pike_json_path` parameter to read explicit `module_path` declaration
2. Probe step 4: `src/name.pmod/` — Cargo-style convention
3. Probe step 5: `src/` with exactly one `*.pmod/` directory — single-module auto-detect

### Updated call sites (7 locations)
- `Install.pmod`: lines 61, 232, 320, 337 — now pass pike.json path
- `LockOps.pmod`: lines 98, 125 — now pass pike.json path
- `Exec.pmod`: line 137 — now passes pike.json path

### `tests/test_26_module_resolution.sh`
Added 5 new test cases (Tests 8-12):
- Test 8: `src/PkgName.pmod/` layout detection
- Test 9: Single-pmod auto-detect in `src/`
- Test 10: Explicit `module_path` field in pike.json
- Test 11: Invalid `module_path` falls back to scanning
- Test 12: Path traversal in `module_path` is rejected

### Docs
- `CHANGELOG.md`: Added `[Unreleased]` entry
- `AGENTS.md`: Updated baseline from 230 to 242 tests

## Verification

```
sh tests/runner.sh  # 242 passed, 0 failed
```

## Breaking changes

None. Fully backward compatible with existing flat and nested layouts.