### PR TITLE
feat(repo): pmp practices what it preaches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: sh tests/test_install.sh
 
       - name: Install Pike modules (PUnit)
-        run: sh bin/pmp install
+        run: sh bin/pmp install --frozen-lockfile
 
       - name: Run Pike unit tests
         run: sh tests/pike_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ modules/
 tests/reports/
 *.o
 *.pike.o
-pike.lock
 .tmp-test-lockfile-io-*
 pike.lock.prev
 .tmp-*

--- a/.omp/extensions/pmp-baseline-guard.ts
+++ b/.omp/extensions/pmp-baseline-guard.ts
@@ -1,0 +1,53 @@
+/**
+ * pmp-baseline-guard.ts
+ * 
+ * Guards pmp's test baseline and invariants:
+ * 1. Test baseline: warns if test count shifts from expected 242
+ * 2. pike.json version edit: reminds to sync Config.pmod
+ * 3. gitignore edit: warns if pike.lock is being re-added
+ */
+
+const EXPECTED_PASSED = 242;
+
+/**
+ * Check test output for baseline drift
+ */
+export function onTestOutput(output: string): string | null {
+    const match = output.match(/(\d+)\s+passed/);
+    if (!match) return null;
+    
+    const actual = parseInt(match[1], 10);
+    if (actual !== EXPECTED_PASSED) {
+        return `[pmp-baseline-guard] WARNING: Test count shifted from ${EXPECTED_PASSED} to ${actual}. ` +
+               `Update AGENTS.md test baseline if this is intentional.`;
+    }
+    return null;
+}
+
+/**
+ * Check pike.json edits for version field changes
+ */
+export function onPikeJsonEdit(newContent: string, oldContent: string): string | null {
+    const oldVersion = oldContent.match(/"version":\s*"([^"]+)"/)?.[1];
+    const newVersion = newContent.match(/"version":\s*"([^"]+)"/)?.[1];
+    
+    if (oldVersion !== newVersion && newVersion) {
+        return `[pmp-baseline-guard] Version change detected in pike.json (${newVersion}). ` +
+               `Remember to also update PMP_VERSION in bin/Pmp.pmod/Config.pmod to match.`;
+    }
+    return null;
+}
+
+/**
+ * Check gitignore edits for pike.lock re-addition
+ */
+export function onGitignoreEdit(newContent: string, oldContent: string): string | null {
+    const hasPikeLock = (content: string) => /^pike\.lock$/m.test(content);
+    
+    if (hasPikeLock(newContent) && !hasPikeLock(oldContent)) {
+        return `[pmp-baseline-guard] WARNING: pike.lock is being re-added to .gitignore. ` +
+               `pmp.lock should remain committed for CI reproducibility. ` +
+               `Do NOT gitignore pike.lock.`;
+    }
+    return null;
+}

--- a/.omp/rules/pike-lock-committed.md
+++ b/.omp/rules/pike-lock-committed.md
@@ -1,0 +1,35 @@
+# Pike Lock Committed
+
+**Type:** Scope-based rule
+**Trigger:** Activates when `pike.json` or `.gitignore` is edited
+
+## Scope
+
+Matches files:
+- `pike.json`
+- `.gitignore`
+
+## When triggered
+
+### On `pike.json` edit
+
+When dependencies in `pike.json` change, the agent **MUST**:
+
+1. **Regenerate lockfile** — Run `sh bin/pmp install` to create/update `pike.lock`
+2. **Verify pike.lock is tracked** — Ensure `pike.lock` is not gitignored
+3. **Commit pike.lock** — Include lockfile changes in the same commit as dependency changes
+
+### On `.gitignore` edit
+
+When editing `.gitignore`, the agent **MUST NOT**:
+
+- Re-add `pike.lock` to `.gitignore` — it should remain committed for reproducibility
+
+## Rationale
+
+pmp is a package manager that advocates for lockfile reproducibility. The project itself must:
+
+- Commit `pike.lock` to git so CI can use `--frozen-lockfile`
+- Never gitignore the lockfile — it enables deterministic builds
+
+This rule prevents regressions where the lockfile gets accidentally gitignored.

--- a/.omp/rules/source-change-doc-sync.md
+++ b/.omp/rules/source-change-doc-sync.md
@@ -1,0 +1,32 @@
+# Source Change Documentation Sync
+
+**Type:** Scope-based rule
+**Trigger:** Activates when source files are edited
+
+## Scope
+
+Matches files:
+- `bin/pmp.pike`
+- `bin/Pmp.pmod/*.pmod`
+- `tests/*.sh`
+
+## When triggered
+
+When editing source files, the agent **MUST**:
+
+1. **Update `CHANGELOG.md`** — Add entry under `[Unreleased]` section documenting the change
+
+2. **Update `ARCHITECTURE.md`** — If structural changes (new modules, changed APIs, new commands)
+
+3. **Update `AGENTS.md`** — If test count changed (242 baseline) or architecture changes
+
+4. **Regenerate lockfile** — If `pike.json` dependencies changed, run `sh bin/pmp install` to update `pike.lock`
+
+## Rationale
+
+pmp is a package manager that preaches reproducibility. The project itself must practice what it preaches:
+- Lockfile committed to git for CI reproducibility
+- Version sync between Config.pmod and pike.json
+- Documentation kept in sync with code
+
+This rule ensures documentation hygiene is maintained alongside code changes.

--- a/.omp/rules/version-sync.md
+++ b/.omp/rules/version-sync.md
@@ -1,0 +1,26 @@
+# Version Sync
+
+**Type:** Scope-based rule
+**Trigger:** Activates when `Config.pmod` is edited
+
+## Scope
+
+Matches files:
+- `bin/Pmp.pmod/Config.pmod`
+
+## When triggered
+
+When editing `Config.pmod`, the agent **MUST**:
+
+1. **Sync `PMP_VERSION`** with `pike.json`'s `"version"` field — They must match exactly
+
+2. **Update `CHANGELOG.md`** — If version changed, add entry under `[Unreleased]` with version bump classification (major/minor/patch)
+
+## Rationale
+
+The `PMP_VERSION` constant in `Config.pmod` is the source of truth for pmp's version. Any version bump must be reflected in both places:
+
+- `Config.pmod`: `constant PMP_VERSION = "X.Y.Z";`
+- `pike.json`: `"version": "X.Y.Z"`
+
+Keeping these in sync ensures consistent version reporting across CLI (`pmp version`), documentation, and lockfile generation.

--- a/.omp/settings.json
+++ b/.omp/settings.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/omp-settings.json",
+  "version": 1,
+  "project": {
+    "name": "pmp",
+    "language": "pike",
+    "test_command": "sh tests/runner.sh"
+  },
   "skills": {
     "enabled": true
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,8 @@ docs/TIGER_STYLE.md    TigerBeetle coding style guide — principles adopted in 
 Packages are downloaded once to `~/.pike/store/` with entries named `{domain}-{owner}-{repo}-{tag}-{sha_prefix16}`. Projects symlink from `./modules/{name}/` to the store entry. Store is shared across projects — deleting `./modules/` does not affect the store.
 
 ### Lockfile (`pike.lock`)
-
+Tab-separated, line-oriented format. Created after `pmp install` or `pmp lock`. Contains exact commit SHAs and content hashes. **Committed to git for reproducible builds** — CI uses `--frozen-lockfile` to ensure deterministic resolution.
 Tab-separated, line-oriented format. Created after `pmp install` or `pmp lock`. Contains exact commit SHAs and content hashes. Should be committed to git for reproducible builds.
-
 Format: `name<TAB>source<TAB>tag<TAB>commit_sha<TAB>content_sha256`
 
 ### Key functions
@@ -232,6 +231,15 @@ CI uses separate workflow files, one concern per file. See [docs/ci.md](docs/ci.
 | `blob-size-policy.yml` | Reject files >1MB on PRs |
 | `dep-update.yml` | Reusable workflow for automatic Pike dependency update PRs (consumed via `uses:` from other repos) |
 
+
+
+### OMP Rules
+
+pmp uses Oh My Pi OMP rules to enforce invariants:
+- `source-change-doc-sync.md` — ensures CHANGELOG.md, ARCHITECTURE.md, and AGENTS.md are kept in sync when source files change
+- `version-sync.md` — ensures PMP_VERSION in Config.pmod matches "version" in pike.json
+- `pike-lock-committed.md` — ensures pike.lock is regenerated and never gitignored
+- Extension: `pmp-baseline-guard.ts` — guards test baseline (242 tests) and version/gitignore invariants
 ## Agent behavior
 
 When an AI agent is working in this repository:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+feat(repo): pmp practices what it preaches — pike.json now has proper name ("pmp"), version ("0.5.0"), and description; pike.lock is committed to git (removed from .gitignore) for CI reproducibility; CI now uses --frozen-lockfile; OMP rules added to enforce these invariants going forward
 feat(cli): `pmp outdated --json` — machine-readable JSON output for tooling and CI integration; exits 1 if any dependencies are outdated, 0 if all up to date
 feat(ci): reusable GitHub Actions workflow `.github/workflows/dep-update.yml` — any Pike project can opt-in to automatic dependency update PRs via `uses: TheSmuks/pmp/.github/workflows/dep-update.yml@main`
 

--- a/pike.json
+++ b/pike.json
@@ -1,6 +1,8 @@
 {
+  "name": "pmp",
+  "version": "0.5.0",
+  "description": "Pike Module Package Manager",
   "dependencies": {
     "punit-tests": "github.com/TheSmuks/punit-tests"
-  },
-  "name": "test"
+  }
 }

--- a/pike.lock
+++ b/pike.lock
@@ -1,0 +1,3 @@
+# pmp lockfile v1 — DO NOT EDIT
+# name	source	tag	commit_sha	content_sha256
+punit-tests	github.com/TheSmuks/punit-tests	v1.3.0	8be32a55f685dfc32a07233dbd79c0b5c6ac53c6	263a3d4f74090fae83f7c1d7e122eec6f3db5618a375d22ccb935186414ae15e


### PR DESCRIPTION
## Summary

pmp preaches pike.json, lockfile reproducibility, and content-addressable store — but the project itself wasn't practicing it. This fix makes pmp dogfood its own features.

## Changes

| File | Change |
|------|--------|
| `pike.json` | Proper name "pmp", version "0.5.0", description |
| `.gitignore` | Removed `pike.lock` from gitignore |
| `.github/workflows/ci.yml` | Uses `--frozen-lockfile` for reproducibility |
| `.omp/settings.json` | Added project metadata |
| `.omp/rules/source-change-doc-sync.md` | NEW — doc sync on source changes |
| `.omp/rules/version-sync.md` | NEW — Config.pmod ↔ pike.json version sync |
| `.omp/rules/pike-lock-committed.md` | NEW — lockfile hygiene enforcement |
| `.omp/extensions/pmp-baseline-guard.ts` | NEW — guards test baseline (242 tests) |
| `CHANGELOG.md` | Added entry under [Unreleased] |
| `AGENTS.md` | Updated lockfile docs, added OMP Rules section |

## Verification

```
sh tests/runner.sh       # 242 passed, 0 failed
sh bin/pmp install        # works
sh bin/pmp install --frozen-lockfile  # works
```

## Closes

- Issue #42 (already closed, this completes the dogfooding requirement)